### PR TITLE
fix: add isbackground prop to icon logos

### DIFF
--- a/trades/src/components/icons/BeamSwap.tsx
+++ b/trades/src/components/icons/BeamSwap.tsx
@@ -1,13 +1,22 @@
 import React, { FC, useRef } from 'react';
+import tw from 'twin.macro';
 import { v4 as uuidv4 } from 'uuid';
 
 import { IIconProps, TransitionPath } from '.';
 
-export const BeamSwap: FC<IIconProps> = ({ grayscale, height, width }) => {
+export const BeamSwap: FC<IIconProps> = ({
+  className,
+  grayscale,
+  height,
+  isBackground,
+  width,
+}) => {
   const uuid = useRef(uuidv4());
 
   return (
     <svg
+      className={className}
+      css={[isBackground ? tw`absolute -left-1/2` : '']}
       height={height ?? 14.837}
       viewBox="0 0 400 400"
       width={width ?? 14.832}

--- a/trades/src/components/icons/HermesProtocol.tsx
+++ b/trades/src/components/icons/HermesProtocol.tsx
@@ -3,6 +3,7 @@ import tw from 'twin.macro';
 
 import { IIconProps } from '.';
 export const HermesProtocolIcon: FC<IIconProps> = ({
+  className,
   color,
   grayscale,
   height,
@@ -11,6 +12,7 @@ export const HermesProtocolIcon: FC<IIconProps> = ({
 }) => {
   return (
     <svg
+      className={className}
       css={isBackground ? [tw`absolute -left-1/2`] : ['']}
       height={isBackground ? '100%' : height ?? 28}
       version="1.1"

--- a/trades/src/components/icons/Pancakeswap.tsx
+++ b/trades/src/components/icons/Pancakeswap.tsx
@@ -1,11 +1,13 @@
 import React, { FC, memo } from 'react';
+import tw from 'twin.macro';
 
 import { IIconProps, TransitionPath } from '.';
 
 export const PancakeswapIcon: FC<IIconProps> = memo(
-  ({ className, grayscale, height = 18, width = 18 }) => (
+  ({ className, grayscale, height = 18, isBackground, width = 18 }) => (
     <svg
       className={className}
+      css={[isBackground ? tw`absolute -left-1/2` : '']}
       fill="none"
       height={height}
       viewBox="0 0 18 18"

--- a/trades/src/components/icons/SolarBeam.tsx
+++ b/trades/src/components/icons/SolarBeam.tsx
@@ -1,13 +1,22 @@
 import React, { FC, useRef } from 'react';
+import tw from 'twin.macro';
 import { v4 as uuidv4 } from 'uuid';
 
 import { IIconProps, TransitionCircle, TransitionPath } from '.';
 
-export const Solarbeam: FC<IIconProps> = ({ grayscale, height, width }) => {
+export const Solarbeam: FC<IIconProps> = ({
+  className,
+  grayscale,
+  height,
+  isBackground,
+  width,
+}) => {
   const uuid = useRef(uuidv4());
 
   return (
     <svg
+      className={className}
+      css={[isBackground ? tw`absolute -left-1/2` : '']}
       height={height ?? 28}
       viewBox="0 0 400 400"
       width={width ?? 28}

--- a/trades/src/components/icons/Sushiswap.tsx
+++ b/trades/src/components/icons/Sushiswap.tsx
@@ -1,15 +1,17 @@
 import React, { FC, memo, useRef } from 'react';
+import tw from 'twin.macro';
 import { v4 as uuidv4 } from 'uuid';
 
 import { IIconProps, TransitionG, TransitionPath } from '.';
 
 export const SushiswapIcon: FC<IIconProps> = memo(
-  ({ className, grayscale, height = 14.585, width = 15.925 }) => {
+  ({ className, grayscale, height = 14.585, isBackground, width = 15.925 }) => {
     const uuid = useRef(uuidv4());
 
     return (
       <svg
         className={className}
+        css={[isBackground ? tw`absolute -left-1/2` : '']}
         height={height}
         viewBox="0 0 390.9 393.2"
         width={width}

--- a/trades/src/components/icons/Uniswap.tsx
+++ b/trades/src/components/icons/Uniswap.tsx
@@ -1,11 +1,22 @@
 import React, { FC, memo } from 'react';
+import tw from 'twin.macro';
 
 import { IIconProps, TransitionPath } from '.';
 
 export const UniswapIcon: FC<IIconProps> = memo(
-  ({ active, activeColor, className, color, grayscale, height, width }) => (
+  ({
+    active,
+    activeColor,
+    className,
+    color,
+    grayscale,
+    height,
+    isBackground,
+    width,
+  }) => (
     <svg
       className={className}
+      css={[isBackground ? tw`absolute -left-1/2` : '']}
       height={height ?? 15.139}
       viewBox="0 0 390.9 393.2"
       width={width ?? 14.602}


### PR DESCRIPTION
# Description

Please include a summary of the changes and the related issue in checklist format. Please also include relevant motivation and context.

- [x] add isBackground prop to logo icons

## JIRA Issue
https://romeblockchain.atlassian.net/browse/RT-727?atlOrigin=eyJpIjoiZTA4ZTUzZDRhNDI0NDMzMTk0YzZlNjEyMjEzMTY0NTIiLCJwIjoiaiJ9
## Type of change

Please delete options that are not relevant.

- [x] Bug fix (non-breaking change which fixes an issue)

# How Has This Been Tested?

Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce.

- [x] Switch among beamswap, hermes, pancakeswap, solarbeam, sushiswap and uniswap and confirm that logo icons are on the left

# Checklist:

- [x] I have performed a self-review of my code

