### PR TITLE
fix: use button type to prevent form submission

### DIFF
--- a/banxa/pages/create-order.tsx
+++ b/banxa/pages/create-order.tsx
@@ -270,7 +270,7 @@ export default function CreateOrder() {
                     },
                   })}
                 />
-                <button className="flex  items-center" onClick={() => setSelectCurrencyType('FIAT')}>
+                <button type="button" className="flex  items-center" onClick={() => setSelectCurrencyType('FIAT')}>
                   {source}
                   <ChevronDownIcon className="h-5 w-5 md:h-10 md:w-10 text-current" />
                 </button>
@@ -297,7 +297,7 @@ export default function CreateOrder() {
                   })}
                 />
 
-                <button className="flex items-center" onClick={() => setSelectCurrencyType('CRYPTO')}>
+                <button type="button" className="flex items-center" onClick={() => setSelectCurrencyType('CRYPTO')}>
                   {target}
                   <ChevronDownIcon className="h-5 w-5 md:h-10 md:w-10 text-current" />
                 </button>


### PR DESCRIPTION
## Description
Create order API request is triggered when switching crypto or fiat currency. 
Added `type="button` to prevent unecessary create order calls

## To test
Open network tab.
Try switching tokens/fiat
Create order API request should not be called