### PR TITLE
RT-1058 - Add modal to claim rewards action

### DIFF
--- a/venus/src/components/v2/Layout/ClaimXvsRewardButton/ClaimRewardsModal.tsx
+++ b/venus/src/components/v2/Layout/ClaimXvsRewardButton/ClaimRewardsModal.tsx
@@ -1,0 +1,143 @@
+/** @jsxImportSource @emotion/react */
+import React, { useContext } from 'react';
+import BigNumber from 'bignumber.js';
+import Box from '@mui/material/Box';
+import Typography from '@mui/material/Typography';
+import { useTranslation } from 'translation';
+
+import {
+  useGetXvsReward,
+  useClaimXvsReward,
+} from 'clients/api';
+import { AuthContext } from 'context/AuthContext';
+import toast from 'components/Basic/Toast';
+import { IModalProps, Modal } from 'components/v2/Modal';
+import { Icon } from 'components/v2/Icon';
+import { SecondaryButton } from 'components/v2/Button';
+import useSuccessfulTransactionModal from 'hooks/useSuccessfulTransactionModal';
+import { convertWeiToCoins } from 'utilities/common';
+import { TokenId } from 'types';
+import { useStyles } from './styles';
+
+export interface IClaimRewardsUiProps {
+  amountWei?: BigNumber;
+  isClaimLoading?: boolean;
+  className?: string;
+  isOpened: IModalProps['isOpened'];
+  onClose: IModalProps['handleClose'];
+  handleConfirm?: () => Promise<string>;
+}
+
+const XVS_SYMBOL = 'xvs';
+
+/**
+ * The fade effect on this component results in that it is still rendered after the asset has been set to undefined
+ * when closing the modal.
+ */
+export const ClaimRewardsUi: React.FC<IClaimRewardsUiProps> = ({
+  amountWei,
+  isOpened,
+  isClaimLoading,
+  onClose,
+  handleConfirm,
+}) => {
+  const styles = useStyles();
+
+  const { t, Trans } = useTranslation();
+
+  const { openSuccessfulTransactionModal } = useSuccessfulTransactionModal();
+
+  const readableAmount = convertWeiToCoins({
+    value: amountWei!,
+    tokenId: XVS_SYMBOL,
+    returnInReadableFormat: true,
+  });
+
+  const handleClick = async () => {
+    if (!handleConfirm) return;
+
+    try {
+      const transactionHash = await handleConfirm();
+
+      // Display successful transaction modal
+      openSuccessfulTransactionModal({
+        title: t('claimXvsRewardButton.successfulTransactionModal.title'),
+        message: t('claimXvsRewardButton.successfulTransactionModal.message'),
+        amount: {
+          valueWei: amountWei!,
+          tokenId: 'xvs' as TokenId,
+        },
+        transactionHash,
+      });
+    } catch (error) {
+      toast.error({
+        title: (error as Error).message,
+      });
+    } finally {
+      onClose();
+    }
+  };
+
+  return (
+    <Modal
+      title={
+        <Typography variant="h4" css={styles.modalTitle}>
+          <Trans
+            i18nKey="claimXvsRewardModal.title"
+            components={{
+              Icon: <Icon css={styles.icon} name={XVS_SYMBOL} />,
+            }}
+          />
+        </Typography>
+      }
+      isOpened={isOpened}
+      handleClose={onClose}
+    >
+      <Box display="flex" flexDirection="column" flexGrow="1">
+        <Box paddingY={8} paddingX={4} flexGrow="1" display="flex" justifyContent="center" alignItems="center">
+          <Typography variant="body1" css={styles.modalBody}>
+            {t('claimXvsRewardModal.body', { amount: readableAmount })}
+          </Typography>
+        </Box>
+        <SecondaryButton
+          onClick={handleClick}
+          fullWidth
+          loading={isClaimLoading}
+        >
+          {t('claimXvsRewardModal.submitButton')}
+        </SecondaryButton>
+      </Box>
+    </Modal>
+  );
+};
+
+const ClaimRewardsModal: React.FC<IClaimRewardsUiProps> = props => {
+  const { account } = useContext(AuthContext);
+  const { data: xvsRewardWei } = useGetXvsReward(account?.address);
+  const { t } = useTranslation();
+
+  const { mutateAsync: claimXvsReward, isLoading: isClaimXvsRewardLoading } = useClaimXvsReward();
+
+  const handleClaim = async () => {
+    if (!account?.address) {
+      throw new Error(t('errors.walletNotConnected'));
+    }
+
+    const res = await claimXvsReward({
+      fromAccountAddress: account.address,
+    });
+
+    return res.transactionHash;
+  };
+
+  return (
+    <ClaimRewardsUi
+      {...props}
+      amountWei={xvsRewardWei}
+      isClaimLoading={isClaimXvsRewardLoading}
+      handleConfirm={handleClaim}
+    />
+  );
+};
+
+export default ClaimRewardsModal;

--- a/venus/src/components/v2/Layout/ClaimXvsRewardButton/index.tsx
+++ b/venus/src/components/v2/Layout/ClaimXvsRewardButton/index.tsx
@@ -1,15 +1,13 @@
 /** @jsxImportSource @emotion/react */
-import React, { useContext } from 'react';
+import React, { useContext, useState } from 'react';
 import BigNumber from 'bignumber.js';
-
-import toast from 'components/Basic/Toast';
-import { AuthContext } from 'context/AuthContext';
-import useSuccessfulTransactionModal from 'hooks/useSuccessfulTransactionModal';
-import { useGetXvsReward, useClaimXvsReward } from 'clients/api';
 import { useTranslation } from 'translation';
-import { TokenId } from 'types';
+
+import { AuthContext } from 'context/AuthContext';
+import { useGetXvsReward, useClaimXvsReward } from 'clients/api';
 import { Icon } from '../../Icon';
 import { SecondaryButton, IButtonProps } from '../../Button';
+import ClaimRewardsModal from './ClaimRewardsModal';
 import { useStyles } from './styles';
 
 const XVS_SYMBOL = 'xvs';
@@ -29,47 +27,41 @@ export const ClaimXvsRewardButtonUi: React.FC<IClaimXvsRewardButton> = ({
   const { t, Trans } = useTranslation();
   const styles = useStyles();
 
-  const { openSuccessfulTransactionModal } = useSuccessfulTransactionModal();
+  const [isClaimRewardModalOpen, setIsClaimRewardModalOpen] = useState(false);
 
   if (!amountWei || amountWei.isEqualTo(0)) {
     return null;
   }
 
-  const handleClick = async () => {
-    try {
-      const transactionHash = await onClaim();
+  const closeClaimRewardModal = () => {
+    setIsClaimRewardModalOpen(false);
+  };
 
-      // Display successful transaction modal
-      openSuccessfulTransactionModal({
-        title: t('claimXvsRewardButton.successfulTransactionModal.title'),
-        message: t('claimXvsRewardButton.successfulTransactionModal.message'),
-        amount: {
-          valueWei: amountWei,
-          tokenId: 'xvs' as TokenId,
-        },
-        transactionHash,
-      });
-    } catch (error) {
-      toast.error({
-        title: (error as Error).message,
-      });
-    }
+  const handleClick = async () => {
+    setIsClaimRewardModalOpen(true);
   };
 
   return (
-    <SecondaryButton
-      data-testid={TEST_ID}
-      css={styles.button}
-      onClick={handleClick}
-      {...otherProps}
-    >
-      <Trans
-        i18nKey="claimXvsRewardButton.title"
-        components={{
-          Icon: <Icon css={styles.icon} name={XVS_SYMBOL} />,
-        }}
+    <>
+      <SecondaryButton
+        data-testid={TEST_ID}
+        css={styles.button}
+        onClick={handleClick}
+        {...otherProps}
+      >
+        <Trans
+          i18nKey="claimXvsRewardButton.title"
+          components={{
+            Icon: <Icon css={styles.icon} name={XVS_SYMBOL} />,
+          }}
+        />
+      </SecondaryButton>
+
+      <ClaimRewardsModal
+        isOpened={isClaimRewardModalOpen}
+        onClose={closeClaimRewardModal}
       />
-    </SecondaryButton>
+    </>
   );
 };
 

--- a/venus/src/components/v2/Layout/ClaimXvsRewardButton/styles.ts
+++ b/venus/src/components/v2/Layout/ClaimXvsRewardButton/styles.ts
@@ -24,5 +24,12 @@ export const useStyles = () => {
       width: ${theme.spacing(6)};
       height: ${theme.spacing(6)};
     `,
+    modalTitle: css`
+      display: flex;
+      align-items: center;
+    `,
+    modalBody: css`
+      font-size: 1.5rem;
+    `,
   };
 };

--- a/venus/src/components/v2/Modal/styles.ts
+++ b/venus/src/components/v2/Modal/styles.ts
@@ -29,6 +29,8 @@ export const useModalStyles = ({
         transform: translate(-50%, -50%);
       }
       ${theme.breakpoints.down('sm')} {
+        display: flex;
+        flex-direction: column;
         width: 100%;
         left: 0;
         top: 0;
@@ -98,7 +100,7 @@ export const useModalStyles = ({
       border-color: ${theme.palette.secondary.light};
       border-radius: 9px;
       color: ${theme.palette.text.secondary};
-      margin-bottom: ${hasTitleComponent ? theme.spacing(0) : theme.spacing(2)};
+      margin-bottom: ${theme.spacing(2)};
       text-transform: none;
 
       :hover:not(:disabled) {
@@ -124,6 +126,11 @@ export const useModalStyles = ({
       ${theme.breakpoints.down('md')} {
         padding-left: ${noHorizontalPadding ? 0 : theme.spacing(3)};
         padding-right: ${noHorizontalPadding ? 0 : theme.spacing(3)};
+      }
+      ${theme.breakpoints.down('sm')} {
+        flex-grow: 1;
+        display: flex;
+        flex-direction: column;
       }
     `,
   };

--- a/venus/src/translation/translations/en.json
+++ b/venus/src/translation/translations/en.json
@@ -82,6 +82,11 @@
     },
     "title": "<Icon/> Claim XVS"
   },
+  "claimXvsRewardModal": {
+    "title": "<Icon/> Claim XVS",
+    "body": "You can claim {{amount}}",
+    "submitButton": "Claim"
+  },
   "connectButton": {
     "title": "Connect wallet"
   },


### PR DESCRIPTION
# Description
- Add modal to the claim rewards, so the user can see the amount of XVS he has

## JIRA Issue
https://romeblockchain.atlassian.net/browse/RT-1058

## Type of change
New feature (non-breaking change which adds functionality)

# How Has This Been Tested?
- Open the venus widget
- If you have accrued rewards you'll be able to see the claim rewards button
- Click it and check that the claim rewards modal displays the amount of XVS you can claim
- Check that the claim modal has both the happy and bad path working

# Checklist:
- [x] I have performed a self-review of my code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [ ] I have updated the regression test document that are relevant to this PR
- [ ] I have completed all regression tests located in the Google Sheet
- [ ] I have added appropriate google analytics events and recorded them in https://docs.google.com/spreadsheets/d/1vVmCcY-jjeOejKUjDmmgCOtY1V49n-3IlBqgnAlGCrc/edit?usp=sharing
