### PR TITLE
RT-1078 - Add collateral factor to market overview

### DIFF
--- a/venus/src/components/v2/Layout/ClaimXvsRewardButton/ClaimRewardsModal.tsx
+++ b/venus/src/components/v2/Layout/ClaimXvsRewardButton/ClaimRewardsModal.tsx
@@ -9,14 +9,15 @@ import {
   useGetXvsReward,
   useClaimXvsReward,
 } from 'clients/api';
+import { TOKENS } from 'constants/tokens';
 import { AuthContext } from 'context/AuthContext';
 import toast from 'components/Basic/Toast';
 import { IModalProps, Modal } from 'components/v2/Modal';
 import { Icon } from 'components/v2/Icon';
 import { SecondaryButton } from 'components/v2/Button';
 import useSuccessfulTransactionModal from 'hooks/useSuccessfulTransactionModal';
-import { convertWeiToCoins } from 'utilities/common';
-import { TokenId } from 'types';
+import useConvertWeiToReadableTokenString from 'hooks/useConvertWeiToReadableTokenString';
+import { Token, TokenId } from 'types';
 import { useStyles } from './styles';
 
 export interface IClaimRewardsUiProps {
@@ -47,10 +48,10 @@ export const ClaimRewardsUi: React.FC<IClaimRewardsUiProps> = ({
 
   const { openSuccessfulTransactionModal } = useSuccessfulTransactionModal();
 
-  const readableAmount = convertWeiToCoins({
-    value: amountWei!,
-    tokenId: XVS_SYMBOL,
-    returnInReadableFormat: true,
+  const readableAmount = useConvertWeiToReadableTokenString({
+    valueWei: amountWei!,
+    token: TOKENS.xvs as Token,
+    minimizeDecimals: true,
   });
 
   const handleClick = async () => {

--- a/venus/src/containers/Main/Market/index.tsx
+++ b/venus/src/containers/Main/Market/index.tsx
@@ -5,7 +5,7 @@ import styled from 'styled-components';
 import { connect } from 'react-redux';
 import { uid } from 'react-uid';
 
-import { getToken } from 'utilities';
+import { convertPercentageFromSmartContract, getToken } from 'utilities';
 import {
   currencyFormatter,
   formatToReadablePercentage,
@@ -103,7 +103,7 @@ const TableWrapper = styled.div`
 
         @media (min-width: 510px) {
           gap: 15px;
-          grid-template-columns: 1fr 1fr auto;
+          grid-template-columns: 1fr 1fr 1fr auto;
         }
       }
 
@@ -294,6 +294,10 @@ function Market({ history, settings }: MarketProps) {
                       <span className={`item-title${item.totalBorrowApy.lt(0) ? ' red' : ' green'}`}>{formatToReadablePercentage(item.totalBorrowApy)} </span>
                       <span className="item-value">({formatToReadablePercentage(item.borrowVenusApy)})</span>
                     </p>
+                  </div>
+                  <div>
+                    <p>Collateral Factor</p>
+                    <p className="item-title">{formatToReadablePercentage(convertPercentageFromSmartContract(item.collateralFactor))}</p>
                   </div>
                   <div>
                     <p>Price</p>

--- a/venus/src/hooks/useConvertWeiToReadableTokenString.ts
+++ b/venus/src/hooks/useConvertWeiToReadableTokenString.ts
@@ -1,0 +1,29 @@
+import { useMemo } from 'react';
+import { ConvertWeiToTokensInput, convertWeiToTokens } from 'utilities';
+
+import PLACEHOLDER_KEY from 'constants/placeholderKey';
+
+export interface UseConvertWeiToReadableTokenStringInput
+  extends Omit<ConvertWeiToTokensInput, 'valueWei' | 'returnInReadableFormat'> {
+  valueWei: ConvertWeiToTokensInput['valueWei'] | undefined;
+}
+
+const useConvertWeiToReadableTokenString = (params: UseConvertWeiToReadableTokenStringInput) =>
+  useMemo(
+    () =>
+      params.valueWei
+        ? convertWeiToTokens({
+            ...(params as ConvertWeiToTokensInput),
+            returnInReadableFormat: true,
+          })
+        : PLACEHOLDER_KEY,
+    [
+      params.valueWei?.toFixed(),
+      params.token,
+      params.minimizeDecimals,
+      params.addSymbol,
+      params.shortenLargeValue,
+    ],
+  );
+
+export default useConvertWeiToReadableTokenString;


### PR DESCRIPTION
# Description
- Show collateral factor in market overview page
- Show more decimals when necessary in the claim rewards modal

## JIRA Issue
https://romeblockchain.atlassian.net/browse/RT-1078

## Type of change
Bug fix (non-breaking change which fixes an issue)

# How Has This Been Tested?
Collateral factors
- Open the Venus widget
- Go to the market overview page and verify that the markets show the corresponding collateral factor

Rewards amount
- If you have rewards accrued, click on the claim rewards button
- Check that the modal show a non-zero amount of rewards

# Checklist:
- [x] I have performed a self-review of my code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [ ] I have updated the regression test document that are relevant to this PR
- [ ] I have completed all regression tests located in the Google Sheet
- [ ] I have added appropriate google analytics events and recorded them in https://docs.google.com/spreadsheets/d/1vVmCcY-jjeOejKUjDmmgCOtY1V49n-3IlBqgnAlGCrc/edit?usp=sharing
