### PR TITLE
RT-1570 - Trader Joe Call-to-action button hover state displays font with the same color as background

### DIFF
--- a/trades/src/components/buttons/ThemeButton.tsx
+++ b/trades/src/components/buttons/ThemeButton.tsx
@@ -24,7 +24,7 @@ const Base = styled(RebassButton)<{
 `;
 
 export const ButtonPrimary = styled(Base)`
-  ${tw`bg-yellow-400 text-dark-400 text-xl`}
+  ${tw`bg-yellow-400 text-dark-400 text-xl hover:bg-gray-800`}
 
   &:disabled {
     ${tw`bg-gray-500 text-gray-300`}


### PR DESCRIPTION
# Description
- Fix text unreadable on some buttons in the swap widget (changed the background color on hover to make the text visible)

## JIRA Issue
https://romeblockchain.atlassian.net/browse/RT-1570

## Type of change
Bug fix (non-breaking change which fixes an issue)
